### PR TITLE
UI: Mostrar resultados estilo SSMS y persistir vista por pestaña de query

### DIFF
--- a/src/main.ps1
+++ b/src/main.ps1
@@ -293,6 +293,15 @@ function New-MainForm {
     $global:lblExecutionTimer = $window.FindName("lblExecutionTimer")
     $global:lblRowCount = $window.FindName("lblRowCount")
     $global:lblConnectionStatus = $lblConnectionStatus
+    if ($tcQueries) {
+        $tcQueries.Add_SelectionChanged({
+                try {
+                    Restore-QueryExecutionState -QueryTabControl $global:tcQueries -ResultTabControl $global:tcResults -MessagesTextBox $global:txtMessages -RowCountLabel $global:lblRowCount
+                } catch {
+                    Write-DzDebug "`t[DEBUG][Queries] Error restaurando vista por pestaña: $($_.Exception.Message)" Yellow
+                }
+            })
+    }
     if ($tvDatabases) {
         try {
             Write-Host "`nAplicando estilo al TreeView..." -ForegroundColor Yellow

--- a/src/modules/GUI.psm1
+++ b/src/modules/GUI.psm1
@@ -1475,6 +1475,12 @@ function Get-MainWindowXaml {
                             <!-- Pestañas de Queries -->
                             <TabControl Name="tcQueries" Grid.Row="0"
                                         Background="{DynamicResource ControlBg}">
+                                <TabControl.ItemContainerStyle>
+                                    <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource {x:Type TabItem}}">
+                                        <Setter Property="FontSize" Value="10"/>
+                                        <Setter Property="Padding" Value="8,2"/>
+                                    </Style>
+                                </TabControl.ItemContainerStyle>
                                 <TabItem Header="+" Name="tabAddQuery"
                                         IsEnabled="True" ToolTip="Nueva consulta"/>
                             </TabControl>
@@ -1487,6 +1493,7 @@ function Get-MainWindowXaml {
                                 <TabControl.ItemContainerStyle>
                                     <Style TargetType="{x:Type TabItem}" BasedOn="{StaticResource {x:Type TabItem}}">
                                         <Setter Property="FontSize" Value="10"/>
+                                        <Setter Property="Padding" Value="8,2"/>
                                     </Style>
                                 </TabControl.ItemContainerStyle>
                                 <TabItem Header="📊 Resultados">


### PR DESCRIPTION
### Motivation
- Hacer que la visualización de resultados sea similar a SSMS para evitar crear muchas pestañas cuando hay múltiples resultsets. 
- Compactar la interfaz de resultados/mensajes (tipografía y padding) para aprovechar mejor el espacio y mostrar más contenido por pantalla. 
- Mantener la vista de resultados por cada pestaña de consulta para poder alternar entre pestañas y recuperar sus resultados y mensajes previos. 

### Description
- Reemplacé la lógica de `Show-MultipleResultSets` para usar una única pestaña "📊 Resultados" que contiene un `ScrollViewer` con un `StackPanel` vertical y varios `DataGrid` (uno por resultset), mostrando los conjuntos en vertical (estilo SSMS). (archivo: `src/modules/Database.psm1`).
- Ajusté tamaños visuales: `FontSize` de grids/headers/mensajes a `10`, filas/headers más compactos y padding reducido en tabs de queries/resultados (archivo: `src/modules/GUI.psm1` y cambios en `Database.psm1`).
- Añadí persistencia por pestaña de query: funciones `Save-ActiveQueryExecutionState` y `Restore-QueryExecutionState` para almacenar/recuperar mensajes, resultsets, filas afectadas, texto del contador y pane seleccionado (archivo: `src/modules/QueriesPad.psm1`).
- Guardé el estado visual al finalizar la ejecución de la consulta en `Execute-QueryCore` (casos con resultsets, filas afectadas o sin resultados) y restauro la vista cuando cambia la pestaña de query añadiendo un `SelectionChanged` en `tcQueries` dentro de `New-MainForm` (archivo: `src/main.ps1`).
- Actualicé `Get-ExportableResultTabs` para detectar `DataGrid` embebidos en el nuevo `ScrollViewer` y mantener la funcionalidad de exportación por conjunto de resultados (archivo: `src/modules/Database.psm1`).

### Testing
- Se aplicaron y commitearon los cambios localmente en la rama de trabajo (commit: `34c244b Ajusta vista de resultados estilo SSMS y persistencia por query tab`).
- Intenté cargar los módulos con `pwsh`/`powershell` para validar la importación dinámica, pero en este entorno esos binarios no están disponibles, por lo que no se pudieron ejecutar pruebas UI automáticas ni comprobaciones de WPF en tiempo de ejecución.
- Realicé comprobaciones de diff/estado y verifiqué que los cambios se guardaron en los archivos: `src/modules/Database.psm1`, `src/modules/QueriesPad.psm1`, `src/modules/GUI.psm1`, `src/main.ps1` (commit exitoso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f4fa646a8832e89245794c647a06d)